### PR TITLE
Update search.ctp

### DIFF
--- a/app/irohajirui-sho/app/views/iroha_datas/search.ctp
+++ b/app/irohajirui-sho/app/views/iroha_datas/search.ctp
@@ -276,10 +276,8 @@ if ($mcount > 0) {
 				echo '</td></tr>';
 			}
 		}
-		if (array_key_exists("IrohaData", $midashis)) {
-			if (($column = $midashi["IrohaData"]["sakuseisya_chuu"]) !== "") {
-				echo "<tr><td>作成者注</td><td>${column}</td></tr>";
-			}
+		if (($column = $midashi["IrohaData"]["sakuseisya_chuu"]) !== "") {
+			echo "<tr><td>作成者注</td><td>${column}</td></tr>";
 		}
 		echo '</table>';
 		echo "</div>";


### PR DESCRIPTION
279行目にあるif文を処理する前提としてあった
if (array_key_exists("IrohaData", $midashis)) {}
を削除。このif文は必要？（読み検索の方には同様の処理はない）